### PR TITLE
fix crash after tas savestate

### DIFF
--- a/src/Windowpane.cs
+++ b/src/Windowpane.cs
@@ -197,7 +197,7 @@ namespace Celeste.Mod.WindowpaneHelper {
 
         public override void Render() {
             // unset group visibility
-            if (!Groups[StylegroundTag]._shouldResetAnyVisible) {
+            if (InGroup && !Groups[StylegroundTag]._shouldResetAnyVisible) {
                 var group = Groups[StylegroundTag];
                 group._shouldResetAnyVisible = true;
                 Groups[StylegroundTag] = group;


### PR DESCRIPTION
for some reasons the game crash after tas savestate in the room exist windowpanel, the easiest way is to fix it in the WindowpaneHelper side, just make sure it containe the key
```
System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Celeste.Mod.WindowpaneHelper.Windowpane.Render() in /home/microlith57/.local/share/Steam/steamapps/common/Celeste/Mods/WindowpaneHelper/src/Windowpane.cs:line 200
```